### PR TITLE
IMPROVEMENT: Increased percieved user input latency v1

### DIFF
--- a/packages/client/src/scenes/Game.ts
+++ b/packages/client/src/scenes/Game.ts
@@ -403,7 +403,7 @@ export class Game extends Scene {
   /**
    * How many updates to send per second
    */
-  fixedTimeStep = 1000 / (60 * 10);
+  fixedTimeStep = 1000 / (60 * 20);
   update(time: number, delta: number): void {
     // skip loop if not connected yet.
     if (!this.room) {

--- a/packages/client/src/scenes/Game.ts
+++ b/packages/client/src/scenes/Game.ts
@@ -15,6 +15,10 @@ type tPlayerSchema = tPlayer<Schema, Schema>;
 type tTileSchema = tTile<Schema>;
 type tPowerUpSchema = tPowerUp<Schema>;
 
+enum eEmitTypes {
+  MOVE = "move",
+}
+
 function splitIntoMatrix(matrixSize: number) {
   return (acc, item) => {
     if (acc!.at(-1)!.length >= matrixSize) acc.push("");
@@ -228,7 +232,7 @@ export class Game extends Scene {
                   x: target.x,
                   y: target.y,
                 };
-                target.emit("moved", emitArgs);
+                target.emit(eEmitTypes.MOVE, emitArgs);
               }
             } catch (error) {
             } finally {
@@ -255,7 +259,7 @@ export class Game extends Scene {
             newSprite.setMask(mask);
             newSprite.setDepth(eRenderDepth.PLAYER);
             playerSprite.data.set("image", newSprite);
-            playerSprite.on("moved", function ({ y, x }) {
+            playerSprite.on(eEmitTypes.MOVE, function ({ y, x }) {
               newSprite.y = y;
               newSprite.x = x;
             });
@@ -289,7 +293,7 @@ export class Game extends Scene {
             healthHud.setY(y + paddingYHud);
           };
           updateHealthPos(player);
-          playerSprite.on("moved", updateHealthPos);
+          playerSprite.on(eEmitTypes.MOVE, updateHealthPos);
           this.data.set(playerId + "healthHud", healthHud);
 
           const usernamePaddingY = paddingY * 1.5;

--- a/packages/client/src/scenes/Game.ts
+++ b/packages/client/src/scenes/Game.ts
@@ -218,12 +218,17 @@ export class Game extends Scene {
           .circle(player.x, player.y, 32, 0xff0000)
           .setDepth(eRenderDepth.PLAYER);
 
+        type tMoveSubFc = (coords: { x: number; y: number }) => unknown;
         const playerSprite = new Proxy(playerSpriteOriginal, {
           set(target, p, newValue, receiver) {
             const returnVal = Reflect.set(target, p, newValue);
             try {
               if (p === "x" || p === "y") {
-                target.emit("moved", { x: target.x, y: target.y });
+                const emitArgs: Parameters<tMoveSubFc>[0] = {
+                  x: target.x,
+                  y: target.y,
+                };
+                target.emit("moved", emitArgs);
               }
             } catch (error) {
             } finally {
@@ -265,12 +270,10 @@ export class Game extends Scene {
         } else {
           const offset = (player.scale || 1) * (16 * 2);
           // Initialize player health above head
-          let paddingX = offset * 1.5;
           const paddingY = offset * 1.1;
           const healthHud = this.add.text(
-            // offset doesnt do much, as its overwritten by renderPlayerMovement.ts
-            player.x - paddingX,
-            player.y + paddingY,
+            player.x,
+            player.y,
             HUD.HEALTH_HEART.repeat(player.health)
               .split("")
               .reduce(splitIntoMatrix(3 * 2), [""]),
@@ -278,22 +281,21 @@ export class Game extends Scene {
           );
           healthHud.setDepth(eRenderDepth.HUD);
           healthHud.setDataEnabled();
-          paddingX = healthHud.displayWidth / 2;
-          healthHud.setData("paddingX", paddingX);
-          healthHud.setData("paddingY", paddingY);
-          const paddingXHud = paddingX,
-            paddingYHud = paddingY;
-          playerSprite.on("moved", function ({ y, x }) {
+          const paddingXHud = healthHud.displayWidth / 2;
+          const paddingYHud = paddingY;
+
+          const updateHealthPos: tMoveSubFc = function ({ x, y }) {
             healthHud.setX(x - paddingXHud);
             healthHud.setY(y + paddingYHud);
-          });
+          };
+          updateHealthPos(player);
+          playerSprite.on("moved", updateHealthPos);
           this.data.set(playerId + "healthHud", healthHud);
 
           const usernamePaddingY = paddingY * 1.5;
           const usernameHud = this.add.text(
-            // offset doesnt do much, as its overwritten by renderPlayerMovement.ts
-            player.x - paddingX,
-            player.y - usernamePaddingY,
+            player.x,
+            player.y,
             player.username,
             {
               fontSize: 24,
@@ -305,12 +307,12 @@ export class Game extends Scene {
           const usernamePaddingX = usernameHud.displayWidth * 0.5;
           usernameHud.setDataEnabled();
           usernameHud.setDepth(eRenderDepth.HUD);
-          usernameHud.setY(player.y - usernamePaddingY);
-          usernameHud.setX(player.x - usernamePaddingX);
-          playerSprite.on("moved", function ({ y, x }) {
+          const updateHudPos: tMoveSubFc = function ({ x, y }) {
             usernameHud.setY(y - usernamePaddingY);
             usernameHud.setX(x - usernamePaddingX);
-          });
+          };
+          updateHudPos(player);
+          playerSprite.on("moved", updateHudPos);
           this.data.set(playerId + "usernameHud", usernameHud);
         }
 

--- a/packages/client/src/scenes/Game.ts
+++ b/packages/client/src/scenes/Game.ts
@@ -214,6 +214,26 @@ export class Game extends Scene {
       (player: tPlayerSchema, playerId: string) => {
         if (!this.sessionIds.has(playerId)) this.sessionIds.add(playerId);
 
+        const playerSpriteOriginal = this.add
+          .circle(player.x, player.y, 32, 0xff0000)
+          .setDepth(eRenderDepth.PLAYER);
+
+        const playerSprite = new Proxy(playerSpriteOriginal, {
+          set(target, p, newValue, receiver) {
+            const returnVal = Reflect.set(target, p, newValue);
+            try {
+              if (p === "x" || p === "y") {
+                target.emit("moved", { x: target.x, y: target.y });
+              }
+            } catch (error) {
+            } finally {
+              return returnVal;
+            }
+          },
+        });
+
+        this.data.set(playerId, playerSprite);
+
         if (player.imageId.startsWith("http")) {
           this.load.image(playerId, player.imageId);
           this.load.once("filecomplete-image-" + playerId, () => {
@@ -230,16 +250,14 @@ export class Game extends Scene {
             newSprite.setMask(mask);
             newSprite.setDepth(eRenderDepth.PLAYER);
             playerSprite.data.set("image", newSprite);
+            playerSprite.on("moved", function ({ y, x }) {
+              newSprite.y = y;
+              newSprite.x = x;
+            });
           });
 
           this.load.start();
         }
-
-        const playerSprite = this.add
-          .circle(player.x, player.y, 32, 0xff0000)
-          .setDepth(eRenderDepth.PLAYER);
-
-        this.data.set(playerId, playerSprite);
 
         if (playerId === this.room.sessionId) {
           this.playerStats.maxHealth = player.health;
@@ -263,6 +281,12 @@ export class Game extends Scene {
           paddingX = healthHud.displayWidth / 2;
           healthHud.setData("paddingX", paddingX);
           healthHud.setData("paddingY", paddingY);
+          const paddingXHud = paddingX,
+            paddingYHud = paddingY;
+          playerSprite.on("moved", function ({ y, x }) {
+            healthHud.setX(x - paddingXHud);
+            healthHud.setY(y + paddingYHud);
+          });
           this.data.set(playerId + "healthHud", healthHud);
 
           const usernamePaddingY = paddingY * 1.5;
@@ -278,10 +302,15 @@ export class Game extends Scene {
               strokeThickness: 8,
             }
           );
-          usernameHud.setDepth(eRenderDepth.HUD);
+          const usernamePaddingX = usernameHud.displayWidth * 0.5;
           usernameHud.setDataEnabled();
-          usernameHud.setData("paddingX", usernameHud.displayWidth / 2);
-          usernameHud.setData("paddingY", usernamePaddingY);
+          usernameHud.setDepth(eRenderDepth.HUD);
+          usernameHud.setY(player.y - usernamePaddingY);
+          usernameHud.setX(player.x - usernamePaddingX);
+          playerSprite.on("moved", function ({ y, x }) {
+            usernameHud.setY(y - usernamePaddingY);
+            usernameHud.setX(x - usernamePaddingX);
+          });
           this.data.set(playerId + "usernameHud", usernameHud);
         }
 

--- a/packages/client/src/scenes/Game.ts
+++ b/packages/client/src/scenes/Game.ts
@@ -218,6 +218,7 @@ export class Game extends Scene {
       (player: tPlayerSchema, playerId: string) => {
         if (!this.sessionIds.has(playerId)) this.sessionIds.add(playerId);
 
+        // Create visual element of player
         const playerSpriteOriginal = this.add
           .circle(player.x, player.y, 32, 0xff0000)
           .setDepth(eRenderDepth.PLAYER);
@@ -243,6 +244,7 @@ export class Game extends Scene {
 
         this.data.set(playerId, playerSprite);
 
+        // Load in discord image
         if (player.imageId.startsWith("http")) {
           this.load.image(playerId, player.imageId);
           this.load.once("filecomplete-image-" + playerId, () => {
@@ -268,10 +270,12 @@ export class Game extends Scene {
           this.load.start();
         }
 
+        // if player data is the currently connected player, update UI variables.
         if (playerId === this.room.sessionId) {
           this.playerStats.maxHealth = player.health;
           this.playerStats.currentHealth = player.health;
         } else {
+          // Render HUDs for other players
           const offset = (player.scale || 1) * (16 * 2);
           // Initialize player health above head
           const paddingY = offset * 1.1;
@@ -335,6 +339,12 @@ export class Game extends Scene {
               case "bombDamage":
                 break;
             }
+          });
+
+        if (player.userInput)
+          $(player.userInput).onChange(() => {
+            if (!player.userInput) return;
+            this.inputPayload = player.userInput;
           });
 
         $(player).onChange(() => {

--- a/packages/client/src/scenes/Game.ts
+++ b/packages/client/src/scenes/Game.ts
@@ -341,11 +341,10 @@ export class Game extends Scene {
             }
           });
 
-        if (player.userInput)
-          $(player.userInput).onChange(() => {
-            if (!player.userInput) return;
-            this.inputPayload = player.userInput;
-          });
+        // Assign user input once, as its a reference, and will get updates from colosyeus.
+        if (player.userInput) {
+          this.inputPayload = player.userInput;
+        }
 
         $(player).onChange(() => {
           const playerSprite = this.data.get(

--- a/packages/client/src/utils/gameManagement/managePlayerInput.ts
+++ b/packages/client/src/utils/gameManagement/managePlayerInput.ts
@@ -1,6 +1,7 @@
 import { Game } from "../../scenes/Game";
 
 export function managePlayerInput(this: Game) {
+  const oldPlayload = Object.entries(this.inputPayload);
   this.inputPayload.up = !!this.input.keyboard?.addKey(
     Phaser.Input.Keyboard.KeyCodes.W
   ).isDown;
@@ -17,5 +18,7 @@ export function managePlayerInput(this: Game) {
     Phaser.Input.Keyboard.KeyCodes.SPACE
   ).isDown;
 
-  this.room.send(0, this.inputPayload);
+  if (oldPlayload.some(([key, state]) => this.inputPayload[key] !== state)) {
+    this.room.send(0, this.inputPayload);
+  }
 }

--- a/packages/client/src/utils/gameManagement/managePlayerInput.ts
+++ b/packages/client/src/utils/gameManagement/managePlayerInput.ts
@@ -1,24 +1,25 @@
+import { tUserInput } from "explosion-gyio";
 import { Game } from "../../scenes/Game";
 
 export function managePlayerInput(this: Game) {
-  const oldPlayload = Object.entries(this.inputPayload);
-  this.inputPayload.up = !!this.input.keyboard?.addKey(
-    Phaser.Input.Keyboard.KeyCodes.W
-  ).isDown;
-  this.inputPayload.left = !!this.input.keyboard?.addKey(
-    Phaser.Input.Keyboard.KeyCodes.A
-  ).isDown;
-  this.inputPayload.down = !!this.input.keyboard?.addKey(
-    Phaser.Input.Keyboard.KeyCodes.S
-  ).isDown;
-  this.inputPayload.right = !!this.input.keyboard?.addKey(
-    Phaser.Input.Keyboard.KeyCodes.D
-  ).isDown;
-  this.inputPayload.placeBomb = !!this.input.keyboard?.addKey(
-    Phaser.Input.Keyboard.KeyCodes.SPACE
-  ).isDown;
+  const oldPlayload = this.inputPayload;
+  const newPayload: tUserInput = {
+    up: !!this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.W).isDown,
+    left: !!this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.A)
+      .isDown,
+    down: !!this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.S)
+      .isDown,
+    right: !!this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.D)
+      .isDown,
+    placeBomb: !!this.input.keyboard?.addKey(
+      Phaser.Input.Keyboard.KeyCodes.SPACE
+    ).isDown,
+  };
 
-  if (oldPlayload.some(([key, state]) => this.inputPayload[key] !== state)) {
-    this.room.send(0, this.inputPayload);
+  for (const key in newPayload) {
+    const typedKey = key as keyof tUserInput;
+    if (newPayload[typedKey] === oldPlayload[typedKey]) continue;
+    this.room.send(0, newPayload);
+    break;
   }
 }

--- a/packages/client/src/utils/gameManagement/renderPlayerMovement.ts
+++ b/packages/client/src/utils/gameManagement/renderPlayerMovement.ts
@@ -13,18 +13,26 @@ export function renderPlayerMovement(this: Game) {
       | Phaser.GameObjects.Text
       | undefined;
 
-    const movementAmount = 0.2;
+    const movementAmount = 0.1;
 
-    if (serverX !== entity.serverX) {
-      const newX = Phaser.Math.Linear(entity.x, serverX, movementAmount);
+    if (serverX !== entity.x) {
+      const newX =
+        Math.abs(serverX - entity.x) <= 0.1
+          ? serverX
+          : Phaser.Math.Linear(entity.x, serverX, movementAmount);
+
       entity.x = newX;
       if (entity.data.has("image")) entity.data.get("image").x = newX;
       if (healthHud) healthHud.setX(newX - healthHud.data.get("paddingX"));
       if (usernameHud)
         usernameHud.setX(newX - usernameHud.data.get("paddingX"));
     }
-    if (serverY !== entity.serverY) {
-      const newY = Phaser.Math.Linear(entity.y, serverY, movementAmount);
+    if (serverY !== entity.y) {
+      const newY =
+        Math.abs(serverY - entity.y) <= 0.1
+          ? serverY
+          : Phaser.Math.Linear(entity.y, serverY, movementAmount);
+
       entity.y = newY;
       if (entity.data.has("image")) entity.data.get("image").y = newY;
       if (healthHud) healthHud.setY(newY + healthHud.data.get("paddingY"));

--- a/packages/client/src/utils/gameManagement/renderPlayerMovement.ts
+++ b/packages/client/src/utils/gameManagement/renderPlayerMovement.ts
@@ -13,8 +13,10 @@ export function renderPlayerMovement(this: Game) {
       | Phaser.GameObjects.Text
       | undefined;
 
+    const movementAmount = 0.2;
+
     if (serverX !== entity.serverX) {
-      const newX = Phaser.Math.Linear(entity.x, serverX, 0.2);
+      const newX = Phaser.Math.Linear(entity.x, serverX, movementAmount);
       entity.x = newX;
       if (entity.data.has("image")) entity.data.get("image").x = newX;
       if (healthHud) healthHud.setX(newX - healthHud.data.get("paddingX"));
@@ -22,7 +24,7 @@ export function renderPlayerMovement(this: Game) {
         usernameHud.setX(newX - usernameHud.data.get("paddingX"));
     }
     if (serverY !== entity.serverY) {
-      const newY = Phaser.Math.Linear(entity.y, serverY, 0.2);
+      const newY = Phaser.Math.Linear(entity.y, serverY, movementAmount);
       entity.y = newY;
       if (entity.data.has("image")) entity.data.get("image").y = newY;
       if (healthHud) healthHud.setY(newY + healthHud.data.get("paddingY"));

--- a/packages/client/src/utils/gameManagement/renderPlayerMovement.ts
+++ b/packages/client/src/utils/gameManagement/renderPlayerMovement.ts
@@ -1,5 +1,38 @@
 import { Game } from "../../scenes/Game";
 
+const bigboicache = new Map<
+  string,
+  {
+    serverPoint: number;
+    moves: number[];
+  }
+>();
+
+/**
+ *
+ * Creates a list of points to translate player movement smoothly.
+ * The array is constructed in reverse, this means we can use .pop to get the latest move, which is a o(1) operation.
+ */
+function createMoves(
+  startPoint: number,
+  serverPoint: number,
+  movementAmount: number,
+  key: string
+) {
+  bigboicache.set(key, {
+    serverPoint,
+    moves: new Array(1 / movementAmount)
+      .fill(0)
+      .map((_, index, { length }) =>
+        Phaser.Math.Linear(
+          startPoint,
+          serverPoint,
+          (length - index) * movementAmount
+        )
+      ),
+  });
+}
+
 export function renderPlayerMovement(this: Game) {
   for (let sessionId of this.sessionIds.values()) {
     // interpolate all player entities
@@ -15,11 +48,34 @@ export function renderPlayerMovement(this: Game) {
 
     const movementAmount = 0.1;
 
-    if (serverX !== entity.x) {
-      const newX =
-        Math.abs(serverX - entity.x) <= 0.1
-          ? serverX
-          : Phaser.Math.Linear(entity.x, serverX, movementAmount);
+    /**
+     * Populate linear X movement cache if the state X changes.
+     */
+    if (
+      Number.isFinite(serverX) &&
+      serverX !== entity.x &&
+      (!bigboicache.get(sessionId + "x") ||
+        bigboicache.get(sessionId + "x")?.serverPoint !== serverX)
+    ) {
+      createMoves(entity.x, serverX, movementAmount, sessionId + "x");
+    }
+
+    /**
+     * Populates linear Y moves if the state for y position changes
+     */
+    if (
+      Number.isFinite(serverY) &&
+      serverY !== entity.y &&
+      (!bigboicache.get(sessionId + "y") ||
+        bigboicache.get(sessionId + "y")?.serverPoint !== serverY)
+    ) {
+      createMoves(entity.y, serverY, movementAmount, sessionId + "y");
+    }
+
+    // If there are moves cached for our current destination, start translating the player sprite towards it.
+    const xMovement = bigboicache.get(sessionId + "x");
+    if (xMovement?.moves.length) {
+      const newX = xMovement.moves.pop()!;
 
       entity.x = newX;
       if (entity.data.has("image")) entity.data.get("image").x = newX;
@@ -27,11 +83,11 @@ export function renderPlayerMovement(this: Game) {
       if (usernameHud)
         usernameHud.setX(newX - usernameHud.data.get("paddingX"));
     }
-    if (serverY !== entity.y) {
-      const newY =
-        Math.abs(serverY - entity.y) <= 0.1
-          ? serverY
-          : Phaser.Math.Linear(entity.y, serverY, movementAmount);
+
+    // If there are moves cached for our current destination, start translating the player sprite towards it.
+    const yMovement = bigboicache.get(sessionId + "y");
+    if (yMovement?.moves.length) {
+      const newY = yMovement.moves.pop()!;
 
       entity.y = newY;
       if (entity.data.has("image")) entity.data.get("image").y = newY;

--- a/packages/client/src/utils/gameManagement/renderPlayerMovement.ts
+++ b/packages/client/src/utils/gameManagement/renderPlayerMovement.ts
@@ -1,6 +1,9 @@
 import { Game } from "../../scenes/Game";
 
-const bigboicache = new Map<
+/**
+ * To have accurate linear interpulation, we calculate all points at change, then execute 1 movement per iteration.
+ */
+const preCalcPlayerMoveCache = new Map<
   string,
   {
     serverPoint: number;
@@ -19,7 +22,7 @@ function createMoves(
   movementAmount: number,
   key: string
 ) {
-  bigboicache.set(key, {
+  preCalcPlayerMoveCache.set(key, {
     serverPoint,
     moves: new Array(1 / movementAmount)
       .fill(0)
@@ -48,8 +51,8 @@ export function renderPlayerMovement(this: Game) {
     if (
       Number.isFinite(serverX) &&
       serverX !== entity.x &&
-      (!bigboicache.get(sessionId + "x") ||
-        bigboicache.get(sessionId + "x")?.serverPoint !== serverX)
+      (!preCalcPlayerMoveCache.get(sessionId + "x") ||
+        preCalcPlayerMoveCache.get(sessionId + "x")?.serverPoint !== serverX)
     ) {
       createMoves(entity.x, serverX, movementAmount, sessionId + "x");
     }
@@ -60,14 +63,14 @@ export function renderPlayerMovement(this: Game) {
     if (
       Number.isFinite(serverY) &&
       serverY !== entity.y &&
-      (!bigboicache.get(sessionId + "y") ||
-        bigboicache.get(sessionId + "y")?.serverPoint !== serverY)
+      (!preCalcPlayerMoveCache.get(sessionId + "y") ||
+        preCalcPlayerMoveCache.get(sessionId + "y")?.serverPoint !== serverY)
     ) {
       createMoves(entity.y, serverY, movementAmount, sessionId + "y");
     }
 
     // If there are moves cached for our current destination, start translating the player sprite towards it.
-    const xMovement = bigboicache.get(sessionId + "x");
+    const xMovement = preCalcPlayerMoveCache.get(sessionId + "x");
     if (xMovement?.moves.length) {
       const newX = xMovement.moves.pop()!;
 
@@ -75,7 +78,7 @@ export function renderPlayerMovement(this: Game) {
     }
 
     // If there are moves cached for our current destination, start translating the player sprite towards it.
-    const yMovement = bigboicache.get(sessionId + "y");
+    const yMovement = preCalcPlayerMoveCache.get(sessionId + "y");
     if (yMovement?.moves.length) {
       const newY = yMovement.moves.pop()!;
 

--- a/packages/client/src/utils/gameManagement/renderPlayerMovement.ts
+++ b/packages/client/src/utils/gameManagement/renderPlayerMovement.ts
@@ -39,12 +39,6 @@ export function renderPlayerMovement(this: Game) {
     const entity = this.data.get(sessionId);
     if (!entity) continue;
     const { serverX, serverY } = entity.data.values;
-    const healthHud = this.data.get(sessionId + "healthHud") as
-      | Phaser.GameObjects.Text
-      | undefined;
-    const usernameHud = this.data.get(sessionId + "usernameHud") as
-      | Phaser.GameObjects.Text
-      | undefined;
 
     const movementAmount = 0.1;
 
@@ -78,10 +72,6 @@ export function renderPlayerMovement(this: Game) {
       const newX = xMovement.moves.pop()!;
 
       entity.x = newX;
-      if (entity.data.has("image")) entity.data.get("image").x = newX;
-      if (healthHud) healthHud.setX(newX - healthHud.data.get("paddingX"));
-      if (usernameHud)
-        usernameHud.setX(newX - usernameHud.data.get("paddingX"));
     }
 
     // If there are moves cached for our current destination, start translating the player sprite towards it.
@@ -90,10 +80,6 @@ export function renderPlayerMovement(this: Game) {
       const newY = yMovement.moves.pop()!;
 
       entity.y = newY;
-      if (entity.data.has("image")) entity.data.get("image").y = newY;
-      if (healthHud) healthHud.setY(newY + healthHud.data.get("paddingY"));
-      if (usernameHud)
-        usernameHud.setY(newY - usernameHud.data.get("paddingY"));
     }
   }
 }

--- a/packages/server/src/rooms/GameRoom.ts
+++ b/packages/server/src/rooms/GameRoom.ts
@@ -163,7 +163,7 @@ export class GameRoom extends Room<GameState> {
     const allMessagesInOrder = Array.from(this.state.players.values())
       .flatMap((player) => {
         const container: [Player, tUserInputQueue][] = [];
-        const input = player.input.get(this.lastUpdate);
+        const input = player.input.get();
         if (input) container.push([player, input]);
 
         return container;

--- a/packages/server/src/schemas/Player.ts
+++ b/packages/server/src/schemas/Player.ts
@@ -1,9 +1,38 @@
-import { MapSchema, type, view } from "@colyseus/schema";
+import { MapSchema, Schema, type, view } from "@colyseus/schema";
 import { BaseTile } from "./BaseTile";
 import { powerUpTypes, tPowerUps } from "./PowerUp";
 import type { tPlayer, tUserInput } from "explosion-gyio";
 
 export type tUserInputQueue = [time: number, message: tUserInput];
+
+export class PlayerInput extends Schema implements tUserInput {
+  constructor(data?: tUserInput) {
+    super();
+    for (const untypedKey in data) {
+      const key = untypedKey as keyof typeof data;
+      this[key] = data[key];
+    }
+  }
+
+  @type("boolean")
+  up = false;
+
+  @type("boolean")
+  left = false;
+
+  @type("boolean")
+  down = false;
+
+  @type("boolean")
+  right = false;
+
+  @type("boolean")
+  placeBomb = false;
+
+  update = (inputPayload: tUserInput) => {
+    this.assign(inputPayload as any);
+  }
+}
 
 export class Player extends BaseTile implements tPlayer {
   private _maxInputQueue = 10;
@@ -57,6 +86,10 @@ export class Player extends BaseTile implements tPlayer {
     },
   };
 
+  @view()
+  @type(PlayerInput)
+  userInput = new PlayerInput();
+
   input = {
     add: (input: tUserInputQueue) => {
       if (!input) return false;
@@ -73,21 +106,26 @@ export class Player extends BaseTile implements tPlayer {
      * @returns
      */
     get: (epochMs?: number) => {
-      if (epochMs)
-        return this._inputQueue.find((currentInput, index, arr) => {
-          if (
-            currentInput[0] <= epochMs &&
-            (!arr[index + 1] || arr[index + 1][0] > epochMs)
-          ) {
-            return true;
-          }
-          return false;
-        });
+      const playerMovement = epochMs
+        ? this._inputQueue.find((currentInput, index, arr) => {
+            if (
+              currentInput[0] <= epochMs &&
+              (!arr[index + 1] || arr[index + 1][0] > epochMs)
+            ) {
+              return true;
+            }
+            return false;
+          })
+        : this._inputQueue.reduce<tUserInputQueue>((prev, current) => {
+            if (prev?.[0] > (current?.[0] || 0)) return prev;
+            return current;
+          }, this._inputQueue.at(0)!);
 
-      return this._inputQueue.reduce<tUserInputQueue>((prev, current) => {
-        if (prev?.[0] > (current?.[0] || 0)) return prev;
-        return current;
-      }, this._inputQueue.at(0)!);
+      if (playerMovement) {
+        this.userInput.update(playerMovement[1]);
+      }
+
+      return playerMovement;
     },
   };
 

--- a/packages/server/src/schemas/Player.ts
+++ b/packages/server/src/schemas/Player.ts
@@ -7,10 +7,13 @@ export type tUserInputQueue = [time: number, message: tUserInput];
 
 export class Player extends BaseTile implements tPlayer {
   private _maxInputQueue = 10;
-  private _inputQueue: tUserInputQueue[] = new Array(this._maxInputQueue).fill(
-    []
-  );
-  private _lastInputQueueIndex = 0;
+  private _inputQueue: tUserInputQueue[] = new Array(this._maxInputQueue)
+    .fill([])
+    .map(() => [
+      Date.now(),
+      { down: false, left: false, placeBomb: false, right: false, up: false },
+    ]);
+  private _lastInputQueueIndex = 1;
 
   @view()
   @type({ map: "number" })
@@ -66,19 +69,25 @@ export class Player extends BaseTile implements tPlayer {
     },
     /**
      *
-     * @param epochMs Gets the last input before, or at this epoch(in ms) time.
+     * @param epochMs Gets the last input before, or at this epoch(in ms) time. If empty, gets the latest movement update
      * @returns
      */
-    get: (epochMs: number) => {
-      return this._inputQueue.find((currentInput, index, arr) => {
-        if (
-          currentInput[0] <= epochMs &&
-          (!arr[index + 1] || arr[index + 1][0] > epochMs)
-        ) {
-          return true;
-        }
-        return false;
-      });
+    get: (epochMs?: number) => {
+      if (epochMs)
+        return this._inputQueue.find((currentInput, index, arr) => {
+          if (
+            currentInput[0] <= epochMs &&
+            (!arr[index + 1] || arr[index + 1][0] > epochMs)
+          ) {
+            return true;
+          }
+          return false;
+        });
+
+      return this._inputQueue.reduce<tUserInputQueue>((prev, current) => {
+        if (prev?.[0] > (current?.[0] || 0)) return prev;
+        return current;
+      }, this._inputQueue.at(0)!);
     },
   };
 

--- a/packages/server/src/utils/gameManagement/managePlayerMovement.ts
+++ b/packages/server/src/utils/gameManagement/managePlayerMovement.ts
@@ -28,6 +28,14 @@ export function managePlayerMovement(
       speedLogScaling(playerSpeedPowerup)) /
     6.25;
 
+  const preventMovement: { [key in keyof typeof message]: boolean } = {
+    down: false,
+    left: false,
+    placeBomb: false,
+    right: false,
+    up: false,
+  };
+
   let movementDelta = getPlayerSpeed(player.powerUpsHelper.get("speed") + 1);
   const originalPlayerCoords = { x: player.x, y: player.y };
   const playerSize =
@@ -61,7 +69,7 @@ export function managePlayerMovement(
       playerSize,
       true
     );
-    if (topCollide) message.up = false;
+    if (topCollide) preventMovement.up = true;
   }
 
   // A
@@ -73,7 +81,7 @@ export function managePlayerMovement(
       playerSize,
       true
     );
-    if (leftCollide) message.left = false;
+    if (leftCollide) preventMovement.left = true;
   }
 
   // S
@@ -85,7 +93,7 @@ export function managePlayerMovement(
       playerSize,
       true
     );
-    if (downCollide) message.down = false;
+    if (downCollide) preventMovement.down = true;
   }
 
   // D
@@ -97,22 +105,25 @@ export function managePlayerMovement(
       playerSize,
       true
     );
-    if (rightCollide) message.right = false;
+    if (rightCollide) preventMovement.right = true;
   }
 
   // Normalize input
   const MOVING_DIAGNAL =
-    (message.up || message.down) && (message.left || message.right);
+    ((message.up && !preventMovement.up) ||
+      (message.down && !preventMovement.down)) &&
+    ((message.left && !preventMovement.left) ||
+      (message.right && !preventMovement.right));
   if (MOVING_DIAGNAL) movementDelta = movementDelta / 2;
 
   // W
-  if (message.up) player.y -= movementDelta;
+  if (message.up && !preventMovement.up) player.y -= movementDelta;
   // A
-  if (message.left) player.x -= movementDelta;
+  if (message.left && !preventMovement.left) player.x -= movementDelta;
   // S
-  if (message.down) player.y += movementDelta;
+  if (message.down && !preventMovement.down) player.y += movementDelta;
   // D
-  if (message.right) player.x += movementDelta;
+  if (message.right && !preventMovement.right) player.x += movementDelta;
 
   const stepSize = getPlayerSpeed(2) / 2;
 

--- a/packages/types/tPlayer.ts
+++ b/packages/types/tPlayer.ts
@@ -1,4 +1,4 @@
-import { tPowerUps } from "../server/src/schemas";
+import { PlayerInput, tPowerUps } from "../server/src/schemas";
 import { tBaseTile } from "./tBaseTile";
 
 /**
@@ -13,5 +13,9 @@ export type tPlayer<T = {}, MapT = Map<tPowerUps, number>> = {
    * Optional because only the player can see their own powerups
    */
   powerUps?: Map<tPowerUps, number> & MapT;
+  /**
+   * Optional because only the player can see their own movement
+   */
+  userInput?: PlayerInput;
   username: string;
 } & tBaseTile<T>;


### PR DESCRIPTION
## Summary
Made user interaction feel more snappy! should be more enjoyable to use.


## Features
 - [x] Lower User move latency by half!
 - [x] Improved Hud Position update efficiency
 - [x] Lowered required server bandwidth used for player input
 - [x] Added re-send logic for user input if packet failed to send.

## Technical
We moved over requiring user input for every frame, to instead carrying over the last user input to the current frame. This, combined with the client only sending a new input payload when their input differs from the server state, lowered the bandwidth/processing strain from the server.

We also fixed the linear interp for player movement. before it would never linearly move the player. Now it does. This was caused by following shoddy documentation from the phaserJs docs. Which suggested us to calculate the interp every frame, based on the current position. Instead, we calculate all steps when the local position differes from server, then apply 1 step every frame/tick (not fixed tick.).